### PR TITLE
Missing module

### DIFF
--- a/peepdf/peepdf.py
+++ b/peepdf/peepdf.py
@@ -30,6 +30,7 @@ import os
 import argparse
 import traceback
 import logging
+import json
 from datetime import datetime as dt
 from operator import attrgetter
 


### PR DESCRIPTION
Used [currently] in https://github.com/digitalsleuth/peepdf-3/blob/main/peepdf/peepdf.py#L381

But the `json` module isn't imported
Added import for it here